### PR TITLE
Add Fiery Warpath "hunt details"

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1532,7 +1532,7 @@
         const attrs = user.viewing_atts.desert_warpath;
         const fw = {};
         if ([1, 2, 3].includes(parseInt(attrs.wave, 10))) {
-            const asType = name => name.replace(/desert|_weak|_epic|_strong/g, "");
+            const asType = name => name.replace(/desert_|_weak|_epic|_strong/g, "");
 
             if (attrs.streak_quantity > 0) {
                 fw.streak = {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1379,6 +1379,7 @@
         "Bristle Woods Rift": addBristleWoodsRiftHuntDetails,
         "Harbour": addHarbourHuntDetails,
         "Fort Rox": addFortRoxHuntDetails,
+        "Fiery Warpath": addFieryWarpathHuntDetails,
         "Sand Crypts": addSandCryptsHuntDetails,
         "Whisker Woods Rift": addWhiskerWoodsRiftHuntDetails,
         "Zokor": addZokorHuntDetails,
@@ -1474,7 +1475,6 @@
      * @param {Object <string, any>} user_post The user state object, after the hunt.
      * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
      */
-
     function addHarbourHuntDetails(message, user, user_post, hunt) {
         const quest = user.quests.QuestHarbour;
         const details = {
@@ -1519,6 +1519,81 @@
     }
 
     /**
+     * Log the mouse populations, remaining total, boss invincibility, and streak data.
+     * MAYBE: Record usage of FW charms, e.g. "targeted mouse was attracted"
+     * charm_ids 534: Archer, 535: Cavalry, 536: Commander, 537: Mage, 538: Scout, 539: Warrior
+     *   540: S Archer, 541: S Cavalry, 542: S Mage, 543: S Scout, 544: S Warrior, 615: S Commander
+     * @param {Object <string, any>} message The message to be sent.
+     * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
+     * @param {Object <string, any>} user_post The user state object, after the hunt.
+     * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
+     */
+    function addFieryWarpathHuntDetails(message, user, user_post, hunt) {
+        const attrs = user.viewing_atts.desert_warpath;
+        const fw = {};
+        if ([1, 2, 3].includes(parseInt(attrs.wave, 10))) {
+            const asType = name => name.replace(/desert|_weak|_epic|_strong/g, "");
+
+            if (attrs.streak_quantity > 0) {
+                fw.streak = {
+                    count: parseInt(attrs.streak_quantity, 10),
+                    type: asType(attrs.streak_type),
+                };
+                fw.streak.increased_on_hunt = (message.caught === 1 &&
+                    fw.streak.type === asType(user_post.viewing_atts.desert_warpath.streak_type));
+            }
+
+            // Track the mice remaining in the wave, per type and in total.
+            let remaining = 0;
+            [
+                "desert_warrior",
+                "desert_warrior_weak",
+                "desert_warrior_epic",
+                "desert_scout",
+                "desert_scout_weak",
+                "desert_scout_epic",
+                "desert_archer",
+                "desert_archer_weak",
+                "desert_archer_epic",
+                "desert_mage",
+                "desert_mage_strong",
+                "desert_cavalry",
+                "desert_cavalry_strong",
+                "desert_artillery"
+            ].filter(name => name in attrs.mice).forEach(mouse => {
+                const q = parseInt(attrs.mice[mouse].quantity, 10);
+                fw[`num_${asType(mouse)}`] = q;
+                remaining += q;
+            });
+            const wave_total = ({1: 105, 2: 185, 3: 260})[attrs.wave];
+            // Support retreats when 10% or fewer total mice remain.
+            fw.morale = remaining / wave_total;
+
+            fw.has_support_mice = (attrs.has_support_mice === "active");
+            if (fw.has_support_mice) {
+                // Calculate the non-rounded `morale_percent` viewing attribute.
+                fw.support_morale = (wave_total - remaining) / (.9 * wave_total);
+            }
+        } else if ([4, "4", "portal"].includes(attrs.wave)) {
+            // If the Warmonger or Artillery Commander was already caught (i.e. Ultimate Charm),
+            // don't record any hunt details since there isn't anything to learn.
+            const boss = attrs.mice[(message.stage === "Portal") ?
+                    "desert_artillery_commander" : "desert_boss"];
+            if (parseInt(boss.quantity, 10) !== 1) {
+                return;
+            }
+            // Theurgy Wardens are "desert_elite_gaurd". Yes, "gaurd".
+            fw.num_warden = parseInt(attrs.mice.desert_elite_gaurd.quantity, 10);
+            fw.boss_invincible = !!fw.num_warden;
+        } else {
+            if (debug_logging) {window.console.warn({record: message, user, user_post, hunt});}
+            throw new Error(`Unknown FW Wave "${attrs.wave}"`);
+        }
+
+        message.hunt_details = fw;
+    }
+
+    /**
      * Track the grub salt level
      * @param {Object <string, any>} message The message to be sent.
      * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
@@ -1559,7 +1634,7 @@
             }
         }
     }
-  
+
     /**
      * For the level-3 districts, report whether the boss was defeated or not.
      * For the Minotaur lair, report the categorical label, number of catches, and meter width.


### PR DESCRIPTION
 - Report remaining mouse counts per wave, & if bosses are invincible.
 - Report `morale` / `support_morale` fields, for Warpath Thrasher computations
 - Report streak count, type, and whether the hunt extended it