### PR TITLE
Add SEH hunt details

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1438,16 +1438,14 @@
      */
     function addEggHuntDetails(message, user, user_post, hunt) {
         const quest = getActiveSEHQuest(user.quests);
-        if (quest) {
+        const post_quest = getActiveSEHQuest(user_post.quests);
+        if (quest && post_quest) {
             message.hunt_details = Object.assign(message.hunt_details || {}, {
                 is_egg_hunt: true,
                 egg_charge_pre: parseInt(quest.charge_quantity, 10),
+                egg_charge_post: parseInt(post_quest.charge_quantity, 10),
                 can_double_eggs: (quest.charge_doubler === "active"),
             });
-            const post_quest = getActiveSEHQuest(user_post.quests);
-            if (post_quest) {
-                message.hunt_details.egg_charge_post = parseInt(post_quest.charge_quantity, 10);
-            }
         }
     }
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1419,14 +1419,14 @@
     function addEggHuntDetails(message, user, user_post, hunt) {
         const quest = getActiveSEHQuest(user.quests);
         if (quest) {
-            const post_quest = getActiveSEHQuest(user_post.quests);
             message.hunt_details = Object.assign(message.hunt_details || {}, {
                 is_egg_hunt: true,
-                egg_charge_pre: quest.charge_quantity,
-                double_eggs: (quest.charge_doubler === "active"),
+                egg_charge_pre: parseInt(quest.charge_quantity, 10),
+                can_double_eggs: (quest.charge_doubler === "active"),
             });
+            const post_quest = getActiveSEHQuest(user_post.quests);
             if (post_quest) {
-                message.hunt_details.egg_charge_post = post_quest.charge_quantity;
+                message.hunt_details.egg_charge_post = parseInt(post_quest.charge_quantity, 10);
             }
         }
     }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1403,9 +1403,32 @@
 
         // TODO: Apply any global hunt details (such as from ongoing events, auras, etc).
         [
+            addEggHuntDetails,
             addLNYHuntDetails,
             addLuckyCatchHuntDetails
         ].forEach(details_func => details_func(message, user, user_post, hunt));
+    }
+
+    /**
+     * Record the Eggscavator Charge level, both before and after the hunt.
+     * @param {Object <string, any>} message The message to be sent.
+     * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
+     * @param {Object <string, any>} user_post The user state object, after the hunt.
+     * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
+     */
+    function addEggHuntDetails(message, user, user_post, hunt) {
+        const quest = getActiveSEHQuest(user.quests);
+        if (quest) {
+            const post_quest = getActiveSEHQuest(user_post.quests);
+            message.hunt_details = Object.assign(message.hunt_details || {}, {
+                is_egg_hunt: true,
+                egg_charge_pre: quest.charge_quantity,
+                double_eggs: (quest.charge_doubler === "active"),
+            });
+            if (post_quest) {
+                message.hunt_details.egg_charge_post = post_quest.charge_quantity;
+            }
+        }
     }
 
     /**
@@ -1723,6 +1746,19 @@
     function getActiveLNYQuest(allQuests) {
         const quest_names = Object.keys(allQuests)
             .filter(name => name.includes("QuestLunarNewYear"));
+        return (quest_names.length
+            ? allQuests[quest_names[0]]
+            : null);
+    }
+
+    /**
+     * Return the active Spring Egg Hunt quest, if possible.
+     * @param {Object <string, Object <string, any>>} allQuests the `user.quests` object containing all of the user's quests
+     * @returns {Object <string, any> | null} The quest if it exists, else `null`
+     */
+    function getActiveSEHQuest(allQuests) {
+        const quest_names = Object.keys(allQuests)
+            .filter(name => name.includes("QuestSpringHunt"));
         return (quest_names.length
             ? allQuests[quest_names[0]]
             : null);


### PR DESCRIPTION
 - Eggscavator Charge Level
 - Whether egg loot is doubled (useful to know for those comparing charge cycles)

IIRC the charge egg dropped from the hunt was from the higher of the two states, pre- vs post-hunt. But I can't be certain, so it's tracking both. It's also possible this behavior changes/changed, and without knowing both pre/post, data sifters may draw the wrong conclusion. (This is also why I'm not bothering with the low/med/high; we could add that or back-calculate & update after we know more.)