### PR TITLE
Fixing hunt details object

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "name": "MHCT (Jacks) MouseHunt Helper",
     "short_name": "MHCT Helper",
     "description": "This extension provides useful links and tracks MouseHunt horn calls for tools like rate calculators.",
-    "version": "19.5.4",
+    "version": "19.9.17",
     "icons": {
         "16": "images/icon16.png",
         "48": "images/icon48.png",

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1525,12 +1525,10 @@
             const asType = name => name.replace(/desert_|_weak|_epic|_strong/g, "");
 
             if (attrs.streak_quantity > 0) {
-                fw.streak = {
-                    count: parseInt(attrs.streak_quantity, 10),
-                    type: asType(attrs.streak_type),
-                };
-                fw.streak.increased_on_hunt = (message.caught === 1 &&
-                    fw.streak.type === asType(user_post.viewing_atts.desert_warpath.streak_type));
+                fw.streak_count = parseInt(attrs.streak_quantity, 10),
+                fw.streak_type = asType(attrs.streak_type),
+                fw.streak_increased_on_hunt = (message.caught === 1 &&
+                    fw.streak_type === asType(user_post.viewing_atts.desert_warpath.streak_type));
             }
 
             // Track the mice remaining in the wave, per type and in total.


### PR DESCRIPTION
hunt_details = { name: value, name: value, ...} can't be multiple levels deep. We can change that if we really need to, but i don't see a reason to yet. So fixing this one to be like all others.

Also forgot to commit version last time, so fixing that.