### PR TITLE
fix: avoid TypeError when determining LNY state

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -738,8 +738,7 @@
         }
 
         const quest = getActiveLNYQuest(user.quests);
-        // TODO: check if the last costumed mouse is caught, not the specific one.
-        if (quest && quest.has_stockpile === "found" && !quest.mice.costumed_pig.includes("caught")) {
+        if (quest && quest.has_stockpile === "found" && !quest.mice.every(boss => boss.is_caught === true)) {
             // Ignore event cheese hunts as the player is attracting the Costumed mice in a specific order.
             const event_cheese = Object.keys(quest.items)
                 .filter(itemName => itemName.search(/lunar_new_year\w+cheese/) >= 0)


### PR DESCRIPTION
the shape of LNY.mice changed to an array, so accessing mice.costumed_* is now invalid

I have an example JSON blob of the "seeking costumed mice in order" state here: https://github.com/tehhowch/mh-helper-extension/commit/ad60f77b5ea559448711bc5fa1e21c17b5c021e5 (i removed some of the "rows" values)