### PR TITLE
Add stage and hunt details for floating islands

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1924,14 +1924,14 @@
     function addFloatingIslandsHuntDetails(message, user, user_post, hunt) {
         const envAttributes = user.environment_atts || user.enviroment_atts;
         const huntingSiteAttributes = envAttributes.hunting_site_atts
+        const lootItems = huntingSiteAttributes.island_loot.reduce((prev, current) => Object.assign(prev, { [current.type]: current.quantity}), {})
 
-        message.hunt_details = {
+        message.hunt_details = Object.assign({
             beforeWarden: huntingSiteAttributes.has_enemy && !huntingSiteAttributes.has_encountered_enemy,
-            atWarden: huntingSiteAttributes.is_enemy_encounter,
-            afterWarden: huntingSiteAttributes.has_enemy && huntingSiteAttributes.has_defeated_enemy,
+            atWarden: !!huntingSiteAttributes.is_enemy_encounter,
+            afterWarden: huntingSiteAttributes.has_enemy && !!huntingSiteAttributes.has_defeated_enemy,
             enemy: huntingSiteAttributes.enemy ? huntingSiteAttributes.enemy.type : null,
-            islandModifiers: huntingSiteAttributes.activated_island_mod_types,
-        }
+        }, lootItems);
     }
 
     /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1926,6 +1926,10 @@
         const huntingSiteAttributes = envAttributes.hunting_site_atts
 
         message.hunt_details = {
+            beforeWarden: huntingSiteAttributes.has_enemy && !huntingSiteAttributes.has_encountered_enemy,
+            atWarden: huntingSiteAttributes.is_enemy_encounter,
+            afterWarden: huntingSiteAttributes.has_enemy && huntingSiteAttributes.has_defeated_enemy,
+            enemy: huntingSiteAttributes.enemy ? huntingSiteAttributes.enemy.type : null,
             islandModifiers: huntingSiteAttributes.activated_island_mod_types,
         }
     }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -831,6 +831,7 @@
         "Cursed City": addLostCityStage,
         "Festive Comet": addFestiveCometStage,
         "Fiery Warpath": addFieryWarpathStage,
+        "Floating Islands": addFloatingIslandsStage,
         "Forbidden Grove": addForbiddenGroveStage,
         "Fort Rox": addFortRoxStage,
         "Furoma Rift": addFuromaRiftStage,
@@ -1533,11 +1534,17 @@
         }
     }
 
+    function addFloatingIslandsStage(message, user, user_post, hunt) {
+        const envAttributes = user.environment_atts || user.enviroment_atts;
+        message.stage = envAttributes.hunting_site_atts.island_name
+    }
+
     /** @type {Object <string, Function>} */
     const location_huntdetails_lookup = {
         "Bristle Woods Rift": addBristleWoodsRiftHuntDetails,
         "Claw Shot City": addClawShotCityHuntDetails,
         "Fiery Warpath": addFieryWarpathHuntDetails,
+        "Floating Islands": addFloatingIslandsHuntDetails,
         "Fort Rox": addFortRoxHuntDetails,
         "Harbour": addHarbourHuntDetails,
         "Sand Crypts": addSandCryptsHuntDetails,
@@ -1911,6 +1918,15 @@
                 // string_stepping: !!attrs.active_augmentations.sste,
                 // elixir_rain: !!attrs.active_augmentations.er,
             };
+        }
+    }
+
+    function addFloatingIslandsHuntDetails(message, user, user_post, hunt) {
+        const envAttributes = user.environment_atts || user.enviroment_atts;
+        const huntingSiteAttributes = envAttributes.hunting_site_atts
+
+        message.hunt_details = {
+            islandModifiers: huntingSiteAttributes.activated_island_mod_types,
         }
     }
 


### PR DESCRIPTION
This adds stage info and modifier info for Floating Islands. I have only tested this on the Law island, so more testing is probably required. 

Stage is the island display name eg. "Law island"

Hunt details contains the following:
*  Island Modifiers. These are the system identifiers for active modifiers eg. [ "empty_sky", "sky_cheese", "ore_bonus" ]. I could investigate changing this to the display name if needed. 
* BeforeWarden, AtWarden, AfterWarden - booleans
* enemy - The warden type if present

Any feedback welcome :) 