### PR TITLE
Fix parsing the amount of loot when >999

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2003,7 +2003,7 @@
 
             let item_name = item_text.substring(item_text.indexOf("item_type=") + 10);
             item_name = item_name.substring(0, item_name.indexOf('"'));
-            const item_amount = parseInt(item_text.match(/[0-9,]+/).toString().replace(/,/g, ''));
+            const item_amount = parseInt(item_text.match(/[0-9,]+/)[0].replace(/,/g, ''));
             const plural_name = $($.parseHTML(item_text)).filter("a").text();
 
             const loot_object = {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2003,7 +2003,7 @@
 
             let item_name = item_text.substring(item_text.indexOf("item_type=") + 10);
             item_name = item_name.substring(0, item_name.indexOf('"'));
-            const item_amount = parseInt(item_text.match(/[0-9]+(,[0-9]+)*/).toString().replace(/,/g, ''));
+            const item_amount = parseInt(item_text.match(/[0-9,]+/).toString().replace(/,/g, ''));
             const plural_name = $($.parseHTML(item_text)).filter("a").text();
 
             const loot_object = {


### PR DESCRIPTION
The regex for parsing the amount of loot had a group around the
thousands separator and subsequent digits. This caused the match
call to return the base match and the group result. After replacing
commas with nothing, this resulted in a very large number.

This was only an issue for loot items that can drop in amounts of 1000
or more, like Gold or Cursed Gold.