### PR TITLE
fix: Avoid stripping trap/base/charm/cheese unless at end of string

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -756,10 +756,10 @@
 
         // Setup components
         const components = [
-            { prop: 'weapon', message_field: 'trap', required: true, replacer: /\ trap/i },
-            { prop: 'base', message_field: 'base', required: true, replacer: /\ base/i },
-            { prop: 'bait', message_field: 'cheese', required: true, replacer: /\ cheese/i },
-            { prop: 'trinket', message_field: 'charm', required: false, replacer: /\ charm/i }
+            { prop: 'weapon', message_field: 'trap', required: true, replacer: /\ trap$/i },
+            { prop: 'base', message_field: 'base', required: true, replacer: /\ base$/i },
+            { prop: 'bait', message_field: 'cheese', required: true, replacer: /\ cheese$/i },
+            { prop: 'trinket', message_field: 'charm', required: false, replacer: /\ charm$/i }
         ];
         // All pre-hunt users must have a weapon, base, and cheese.
         const missing = components.filter(component => component.required === true && !user.hasOwnProperty(`${component.prop}_name`));


### PR DESCRIPTION
Ref #109 

Things still parse properly:
![image](https://user-images.githubusercontent.com/20871346/98832330-4d478780-2402-11eb-8172-f7734655e499.png)
