### PR TITLE
feat: create a development environment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,16 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[*.{yml,yaml}]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = false
+
 # TODO: settings for .html files, .css, etc.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,14 @@ module.exports = {
         ecmaVersion: 6,
     },
     rules: {
+        indent: [
+            'error',
+            4,
+            {
+                SwitchCase: 1,
+                outerIIFEBody: 'off',
+            },
+        ],
         'no-unused-vars': [
             'error',
             { args: 'none' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,8 @@ module.exports = {
             },
         ],
         semi: ['error', 'always'],
+        'no-var': ['warn'],
+        'prefer-const': ['error'],
         'no-unused-vars': [
             'error',
             { args: 'none' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+    env: {
+        browser: true,
+        es6: true,
+        webextensions: true,
+    },
+    extends: "eslint:recommended",
+    globals: {
+        $: false,
+        user: false,
+        lastReadJournalEntryId: false,
+    },
+    parserOptions: {
+        ecmaVersion: 6,
+    },
+    rules: {
+        'no-unused-vars': [
+            'error',
+            { args: 'none' },
+        ]
+    },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
         'prefer-const': ['error'],
         'array-bracket-newline': ['error', 'consistent'],
         'comma-dangle': ['error', 'always-multiline'],
+        'object-curly-spacing': ['error', 'never'],
         'no-unused-vars': [
             'error',
             { args: 'none' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,9 @@ module.exports = {
         ecmaVersion: 6,
     },
     rules: {
-        indent: [
+        'array-bracket-newline': ['error', 'consistent'],
+        'comma-dangle': ['error', 'always-multiline'],
+        'indent': [
             'error',
             4,
             {
@@ -22,15 +24,15 @@ module.exports = {
                 outerIIFEBody: 'off',
             },
         ],
-        semi: ['error', 'always'],
-        'no-var': ['warn'],
-        'prefer-const': ['error'],
-        'array-bracket-newline': ['error', 'consistent'],
-        'comma-dangle': ['error', 'always-multiline'],
-        'object-curly-spacing': ['error', 'never'],
+        'no-unneeded-ternary': ['error'],
         'no-unused-vars': [
             'error',
             { args: 'none' },
-        ]
+        ],
+        'no-var': ['warn'],
+        'object-curly-spacing': ['error', 'never'],
+        'object-curly-newline': ['error'],
+        'prefer-const': ['error'],
+        'semi': ['error', 'always'],
     },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
         semi: ['error', 'always'],
         'no-var': ['warn'],
         'prefer-const': ['error'],
+        'array-bracket-newline': ['error', 'consistent'],
+        'comma-dangle': ['error', 'always-multiline'],
         'no-unused-vars': [
             'error',
             { args: 'none' },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
                 outerIIFEBody: 'off',
             },
         ],
+        semi: ['error', 'always'],
         'no-unused-vars': [
             'error',
             { args: 'none' },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI Lint & Test
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - src/**
+  pull_request:
+    paths:
+      - src/**
+      - tests/**
+      - .github/workflows/**
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npx eslint src
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Setup package & env
+      run: npm run build --if-present
+    - name: Run tests
+      env:
+        CI: true
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-﻿# General-purpose ignores
+﻿node_modules
+
+# General-purpose ignores
 client_secret_*
 [Tt]humbs.db
 *.DS_Store

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+    "include": ["src/**/*"],
+    "typeAcquisition": {
+        "include": [
+            "chrome",
+            "jquery",
+        ]
+    },
+    "compilerOptions": {
+        "target": "es6",
+        "lib":[
+            "es2017",
+            "dom",
+        ]
+    },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,914 @@
+{
+  "name": "mhct-extension-env",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
+      "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "mhct-extension-env",
+  "version": "1.0.0",
+  "description": "Dev environment for the MHCT browser extension",
+  "homepage": "https://github.com/mh-community-tools/mh-helper-extension#readme",
+  "license": "MIT",
+  "keywords": [
+    "mousehunt"
+  ],
+  "author": {
+    "name": "DevJackSmith",
+    "url": "https://github.com/DevJackSmith/"
+  },
+  "maintainers": [
+    {
+      "name": "AardWolf",
+      "url": "https://github.com/AardWolf/"
+    },
+    {
+      "name": "DevJackSmith",
+      "url": "https://github.com/DevJackSmith/"
+    },
+    {
+      "name": "tehhowch",
+      "url": "https://github.com/tehhowch/"
+    },
+    {
+      "name": "tsitu",
+      "url": "https://github.com/tsitu/"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/mh-community-tools/mh-helper-extension/issues"
+  },
+  "scripts": {
+    "test": "echo 'Nothing to see here, move along'"
+  },
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mh-community-tools/mh-helper-extension.git"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mh-community-tools/mh-helper-extension.git"
+  },
+  "devDependencies": {
+    "eslint": "^7.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/mh-community-tools/mh-helper-extension/issues"
   },
   "scripts": {
+    "lint": "eslint src",
     "test": "echo 'Nothing to see here, move along'"
   },
   "private": true,

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,7 +1,3 @@
-body {
-	/* min-width: 400px; */
-}
-
 .container.well {
 	background-color: #bbb;
 	margin-bottom: 0;
@@ -37,7 +33,9 @@ body {
 }
 
 /* Hide default HTML checkbox */
-.switch input {display:none;}
+.switch input {
+  display: none;
+}
 
 /* The slider */
 .slider {

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -33,7 +33,7 @@ function check_settings(callback) {
         horn_volume: 100, // defaults
         horn_alert: false, // defaults
         horn_webalert: false, // defaults
-        track_crowns: true // defaults
+        track_crowns: true, // defaults
     },
     settings => callback(settings));
 }
@@ -75,7 +75,7 @@ function icon_timer_updateBadge(tab_id, settings) {
     chrome.tabs.sendMessage(tab_id, request, response => {
         if (chrome.runtime.lastError || !response) {
             const logInfo = {tab_id, request, response, time: new Date(),
-                message: "Error occurred while updating badge icon timer."
+                message: "Error occurred while updating badge icon timer.",
             };
             if (chrome.runtime.lastError) {
                 logInfo.message += `\n${chrome.runtime.lastError.message}`;
@@ -188,7 +188,7 @@ function submitCrowns(crowns) {
             mode: "cors",
             method: "POST",
             credentials: "omit",
-            body: payload
+            body: payload,
         }).then((response) => resolve(response.ok
             ? crowns.bronze + crowns.silver + crowns.gold + crowns.platinum + crowns.diamond
             : false
@@ -196,7 +196,7 @@ function submitCrowns(crowns) {
             window.console.error({
                 "message": "Error submitting user crowns",
                 "error": error,
-                "crowns": crowns
+                "crowns": crowns,
             });
             resolve(false);
         });

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -75,8 +75,7 @@ function icon_timer_updateBadge(tab_id, settings) {
     chrome.tabs.sendMessage(tab_id, request, response => {
         if (chrome.runtime.lastError || !response) {
             const logInfo = {tab_id, request, response, time: new Date(),
-                message: "Error occurred while updating badge icon timer.",
-            };
+                message: "Error occurred while updating badge icon timer."};
             if (chrome.runtime.lastError) {
                 logInfo.message += `\n${chrome.runtime.lastError.message}`;
             }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -44,15 +44,15 @@ function check_settings(callback) {
  */
 function icon_timer_find_open_mh_tab(settings) {
     chrome.tabs.query({'url': ['*://www.mousehuntgame.com/*', '*://apps.facebook.com/mousehunt/*']},
-    found_tabs => {
-        const mhTab = found_tabs[0];
-        if (mhTab && (!mhTab.status || mhTab.status === "complete")) {
-            icon_timer_updateBadge(mhTab.id, settings);
-        } else {
-            // The tab was either not found, or is still loading.
-            icon_timer_updateBadge(false, settings);
-        }
-    });
+        (found_tabs) => {
+            const [mhTab] = found_tabs;
+            if (mhTab && (!mhTab.status || mhTab.status === "complete")) {
+                icon_timer_updateBadge(mhTab.id, settings);
+            } else {
+                // The tab was either not found, or is still loading.
+                icon_timer_updateBadge(false, settings);
+            }
+        });
 }
 
 // Notifications
@@ -189,9 +189,10 @@ function submitCrowns(crowns) {
             method: "POST",
             credentials: "omit",
             body: payload
-        }).then(response => resolve(!response.ok ? false :
-                crowns.bronze + crowns.silver + crowns.gold + crowns.platinum + crowns.diamond)
-        ).catch(error => {
+        }).then((response) => resolve(response.ok
+            ? crowns.bronze + crowns.silver + crowns.gold + crowns.platinum + crowns.diamond
+            : false
+        )).catch((error) => {
             window.console.error({
                 "message": "Error submitting user crowns",
                 "error": error,

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -60,7 +60,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             file_link = chrome.extension.getURL('third_party/tsitu_auto_loader');
         }
         // Forwards messages from popup to main script
-        window.postMessage({ "mhct_message": request.mhct_link, "file_link": file_link }, "*");
+        window.postMessage({"mhct_message": request.mhct_link, "file_link": file_link}, "*");
     } else if (request.mhct_link === "huntTimer") {
         // Check for a King's Reward, otherwise report the displayed time until next horn.
         let message = "Logged out";
@@ -73,7 +73,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
         sendResponse(message);
     } else if (request.mhct_link === "show_horn_alert") {
-        window.postMessage({ "mhct_message": request.mhct_link }, "*");
+        window.postMessage({"mhct_message": request.mhct_link}, "*");
     }
 });
 
@@ -96,7 +96,7 @@ window.addEventListener("message",
                 "settings": data.settings,
             }, event.origin));
         } else if (data.mhct_log_request === 1) {
-            chrome.runtime.sendMessage({ "log": data });
+            chrome.runtime.sendMessage({"log": data});
         }
     },
     false

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -107,7 +107,7 @@ window.addEventListener("message",
  * @returns {Promise <Object <string, any>>} The extension's settings
  */
 function getSettings() {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
         chrome.storage.sync.get({
             success_messages: true, // defaults
             error_messages: true, // defaults

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -32,14 +32,14 @@ s.onload = () => {
     // Display Tsitu's Loader
     chrome.storage.sync.get({
         tsitu_loader_on: false,
-        tsitu_loader_offset: 80
+        tsitu_loader_offset: 80,
     }, items => {
         if (items.tsitu_loader_on) {
             // There must be a better way of doing this
             window.postMessage({
                 "mhct_message": 'tsitu_loader',
                 "tsitu_loader_offset": items.tsitu_loader_offset,
-                "file_link": chrome.runtime.getURL('third_party/tsitu_auto_loader')
+                "file_link": chrome.runtime.getURL('third_party/tsitu_auto_loader'),
             }, "*");
         }
     });
@@ -53,7 +53,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         "mhmh",
         "ryonn",
         "horn",
-        "tsitu_loader"
+        "tsitu_loader",
     ].includes(request.mhct_link)) {
         let file_link = '';
         if (request.mhct_link == "tsitu_loader") {
@@ -86,14 +86,14 @@ window.addEventListener("message",
             getSettings()
                 .then(settings => event.source.postMessage({
                     "mhct_settings_response": 1,
-                    "settings": settings
+                    "settings": settings,
                 }, event.origin));
         } else if (data.mhct_crown_update === 1) {
             data.origin = event.origin;
             chrome.runtime.sendMessage(data, wasSubmitted => event.source.postMessage({
                 "mhct_message": "crownSubmissionStatus",
                 "submitted": wasSubmitted,
-                "settings": data.settings
+                "settings": data.settings,
             }, event.origin));
         } else if (data.mhct_log_request === 1) {
             chrome.runtime.sendMessage({ "log": data });
@@ -118,7 +118,7 @@ function getSettings() {
             horn_volume: 100, // defaults
             horn_alert: false, // defaults
             horn_webalert: false, // defaults
-            track_crowns: true // defaults
+            track_crowns: true, // defaults
         },
         items => {
             if (chrome.runtime.lastError) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -333,7 +333,7 @@
          */
         badgeGroups.forEach(group => {
             const type = group.type;
-            if (payload.hasOwnProperty(type)) {
+            if (Object.prototype.hasOwnProperty.call(payload, type)) {
                 payload[type] = group.count;
             }
         });
@@ -493,7 +493,7 @@
 
         let convertible;
         for (const key in response.items) {
-            if (!response.items.hasOwnProperty(key)) continue;
+            if (!Object.prototype.hasOwnProperty.call(response.items, key)) continue;
             if (convertible) {
                 window.console.log("MHHH: Multiple items are not supported (yet)");
                 return;
@@ -762,7 +762,9 @@
             { prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i }
         ];
         // All pre-hunt users must have a weapon, base, and cheese.
-        const missing = components.filter(component => component.required === true && !user.hasOwnProperty(`${component.prop}_name`));
+        const missing = components.filter(component => component.required === true
+            && !Object.prototype.hasOwnProperty.call(user, `${component.prop}_name`)
+        );
         if (missing.length) {
             window.console.error(`MH Helper: Missing required setup component: ${missing.map(c => c.message_field).join(', ')}`);
             return null;
@@ -2030,7 +2032,7 @@
             const item_amount = parseInt(item_text.match(/\d+[\d,]*/)[0].replace(/,/g, ''), 10);
             const plural_name = $($.parseHTML(item_text)).filter("a").text();
 
-            if (!inventory.hasOwnProperty(item_name)) {
+            if (!Object.prototype.hasOwnProperty.call(inventory, item_name)) {
                 if (debug_logging) window.console.log(`Looted "${item_name}", but it is not in user inventory`);
                 return null;
             }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -357,9 +357,9 @@
         const map = {
             mice: getMapMice(resp),
             id: resp.treasure_map.map_id,
-            name: resp.treasure_map.name.replace(/\ treasure/i, '')
-                .replace(/rare\ /i, '')
-                .replace(/common\ /i, '')
+            name: resp.treasure_map.name.replace(/ treasure/i, '')
+                .replace(/rare /i, '')
+                .replace(/common /i, '')
                 .replace(/Ardouous/i, 'Arduous'),
             user_id: resp.user.user_id,
             entry_timestamp: Math.round(Date.now() / 1000)
@@ -756,10 +756,10 @@
 
         // Setup components
         const components = [
-            { prop: 'weapon', message_field: 'trap', required: true, replacer: /\ trap$/i },
-            { prop: 'base', message_field: 'base', required: true, replacer: /\ base$/i },
-            { prop: 'bait', message_field: 'cheese', required: true, replacer: /\ cheese$/i },
-            { prop: 'trinket', message_field: 'charm', required: false, replacer: /\ charm$/i }
+            { prop: 'weapon', message_field: 'trap', required: true, replacer: / trap$/i },
+            { prop: 'base', message_field: 'base', required: true, replacer: / base$/i },
+            { prop: 'bait', message_field: 'cheese', required: true, replacer: / cheese$/i },
+            { prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i }
         ];
         // All pre-hunt users must have a weapon, base, and cheese.
         const missing = components.filter(component => component.required === true && !user.hasOwnProperty(`${component.prop}_name`));
@@ -808,9 +808,9 @@
             }
             // Remove HTML tags and other text around the mouse name.
             message.mouse = journal.render_data.text
-                .replace(/^.*?;\">/, '')    // Remove all text through the first sequence of `;">`
+                .replace(/^.*?;">/, '')    // Remove all text through the first sequence of `;">`
                 .replace(/<\/a>.*/i, '')    // Remove text after the first <a href>'s closing tag </a>
-                .replace(/\ mouse$/i, '');  // Remove " [Mm]ouse" if it is not a part of the name (e.g. Dread Pirate Mousert)
+                .replace(/ mouse$/i, '');  // Remove " [Mm]ouse" if it is not a part of the name (e.g. Dread Pirate Mousert)
         }
 
         const quest = getActiveLNYQuest(user.quests);
@@ -1064,7 +1064,7 @@
         if (user.quests.QuestLabyrinth.status === "hallway") {
             const hallway = user.quests.QuestLabyrinth.hallway_name;
             // Remove first word (like Short)
-            message.stage = hallway.substr(hallway.indexOf(" ") + 1).replace(/\ hallway/i, '');
+            message.stage = hallway.substr(hallway.indexOf(" ") + 1).replace(/ hallway/i, '');
         } else {
             // Not recording intersections at this time.
             message.location = null;

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -637,8 +637,8 @@
                             name: "Desert Heater Base",
                             quantity: 1,
                         };
-                        const items = [{ id: loot.item_id, name: lootName, quantity: lootQty }];
-                        if (debug_logging) { window.console.log({ desert_heater_loot: items }); }
+                        const items = [{id: loot.item_id, name: lootName, quantity: lootQty}];
+                        if (debug_logging) { window.console.log({desert_heater_loot: items}); }
 
                         submitConvertible(convertible, items, hunt_response.user.user_id);
                     }
@@ -676,8 +676,8 @@
                             name: "Gilded Charm",
                             quantity: 1,
                         };
-                        const items = [{ id: 114, name: "SUPER|brie+", quantity: lootQty }];
-                        if (debug_logging) { window.console.log({ gilded_charm: items }); }
+                        const items = [{id: 114, name: "SUPER|brie+", quantity: lootQty}];
+                        if (debug_logging) { window.console.log({gilded_charm: items}); }
 
                         submitConvertible(convertible, items, hunt_response.user.user_id);
                     }
@@ -756,10 +756,10 @@
 
         // Setup components
         const components = [
-            { prop: 'weapon', message_field: 'trap', required: true, replacer: / trap$/i },
-            { prop: 'base', message_field: 'base', required: true, replacer: / base$/i },
-            { prop: 'bait', message_field: 'cheese', required: true, replacer: / cheese$/i },
-            { prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i },
+            {prop: 'weapon', message_field: 'trap', required: true, replacer: / trap$/i},
+            {prop: 'base', message_field: 'base', required: true, replacer: / base$/i},
+            {prop: 'bait', message_field: 'cheese', required: true, replacer: / cheese$/i},
+            {prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i},
         ];
         // All pre-hunt users must have a weapon, base, and cheese.
         const missing = components.filter(component => component.required === true
@@ -1577,7 +1577,7 @@
         const attrs = user.environment_atts || user.enviroment_atts;
         switch (attrs.state) {
             case "tower": {
-                const { floor } = attrs;
+                const {floor} = attrs;
                 let stageName;
 
                 if (floor >= 1 && floor % 8 === 0) {
@@ -2012,7 +2012,7 @@
     function addFloatingIslandsHuntDetails(message, user, user_post, hunt) {
         const envAttributes = user.environment_atts || user.enviroment_atts;
         const huntingSiteAttributes = envAttributes.hunting_site_atts;
-        const lootItems = huntingSiteAttributes.island_loot.reduce((prev, current) => Object.assign(prev, { [current.type]: current.quantity}), {});
+        const lootItems = huntingSiteAttributes.island_loot.reduce((prev, current) => Object.assign(prev, {[current.type]: current.quantity}), {});
 
         message.hunt_details = Object.assign(message.hunt_details, lootItems);
     }
@@ -2048,7 +2048,7 @@
                 plural_name: item_amount > 1 ? plural_name : '',
             };
 
-            if (debug_logging) { window.console.log({ message: "Loot object", loot_object }); }
+            if (debug_logging) { window.console.log({message: "Loot object", loot_object}); }
 
             return loot_object;
         }).filter(loot => loot);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1572,7 +1572,7 @@
     function addValourRiftStage(message, user, user_post, hunt) {
         const attrs = user.environment_atts || user.enviroment_atts;
         switch (attrs.state) {
-            case "tower":
+            case "tower": {
                 let floor = attrs.floor;
                 let stageName;
 
@@ -1594,6 +1594,7 @@
 
                 message.stage = stageName;
                 break;
+            }
             case "farming":
                 message.stage = "Outside";
                 break;

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -367,8 +367,8 @@
 
         map.extension_version = formatVersion(mhhh_version);
 
-       // Send to database
-       sendMessageToServer(map_intake_url, map);
+        // Send to database
+        sendMessageToServer(map_intake_url, map);
     }
 
     /**
@@ -856,9 +856,11 @@
         if (env) {
             const is_normal = user.quests[env.quest].is_normal.toString();
             Object.assign(message.location, env[is_normal]);
-        } else if (["Living Garden", "Twisted Garden",
-                "Lost City", "Cursed City",
-                "Sand Dunes", "Sand Crypts"].includes(message.location.name)) {
+        } else if ([
+            "Living Garden", "Twisted Garden",
+            "Lost City", "Cursed City",
+            "Sand Dunes", "Sand Crypts",
+        ].includes(message.location.name)) {
             if (debug_logging) {window.console.warn({record: message, user, user_post, hunt});}
             throw new Error(`MHHH: Unexpected location id ${message.location.id} for LG-area location`);
         }
@@ -1834,8 +1836,9 @@
         } else if ([4, "4", "portal"].includes(attrs.wave)) {
             // If the Warmonger or Artillery Commander was already caught (i.e. Ultimate Charm),
             // don't record any hunt details since there isn't anything to learn.
-            const boss = attrs.mice[(message.stage === "Portal") ?
-                    "desert_artillery_commander" : "desert_boss"];
+            const boss = (message.stage === "Portal")
+                ? attrs.mice.desert_artillery_commander
+                : attrs.mice.desert_boss;
             if (parseInt(boss.quantity, 10) !== 1) {
                 return;
             }
@@ -1875,8 +1878,9 @@
             });
         }
         // The mage tower's auto-catch can be applied during Day and Dawn phases, too.
-        const tower_state = quest.tower_status.includes("inactive") ? 0
-                : parseInt(quest.fort.t.level, 10);
+        const tower_state = quest.tower_status.includes("inactive")
+            ? 0
+            : parseInt(quest.fort.t.level, 10);
         details.can_autocatch_any = (tower_state >= 2);
 
         message.hunt_details = Object.assign(message.hunt_details, details);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -119,7 +119,7 @@
             map_id: user.quests.QuestRelicHunter.default_map_id,
             action: "map_info",
             uh: user.unique_hash,
-            last_read_journal_entry_id: lastReadJournalEntryId
+            last_read_journal_entry_id: lastReadJournalEntryId,
         };
         $.post('https://www.mousehuntgame.com/managers/ajax/users/treasuremap.php', payload, null, 'json')
             .done(data => {
@@ -227,9 +227,9 @@
                         page_class: "Camp",
                         hg_is_ajax: 1,
                         last_read_journal_entry_id: lastReadJournalEntryId,
-                        uh: user.unique_hash
+                        uh: user.unique_hash,
                     },
-                    dataType: "json"
+                    dataType: "json",
                 }).done(userRqResponse => {
                     if (debug_logging) {window.console.log({message: "Got user object, invoking huntSend", userRqResponse});}
                     hunt_xhr.addEventListener("loadend", () => {
@@ -297,7 +297,7 @@
                 "mhct_log_request": 1,
                 "is_error": true,
                 "crown_submit_xhr_response": xhr.responseJSON,
-                "reason": "Unable to determine King's Crowns"
+                "reason": "Unable to determine King's Crowns",
             }, window.origin);
             return;
         }
@@ -318,7 +318,7 @@
             silver: 0,
             gold: 0,
             platinum: 0,
-            diamond: 0
+            diamond: 0,
         };
 
         /** Rather than compute counts ourselves, use the `badge` display data.
@@ -344,7 +344,7 @@
         window.postMessage({
             "mhct_crown_update": 1,
             "crowns": payload,
-            "settings": settings
+            "settings": settings,
         }, window.origin);
     }
 
@@ -362,7 +362,7 @@
                 .replace(/common /i, '')
                 .replace(/Ardouous/i, 'Arduous'),
             user_id: resp.user.user_id,
-            entry_timestamp: Math.round(Date.now() / 1000)
+            entry_timestamp: Math.round(Date.now() / 1000),
         };
 
         map.extension_version = formatVersion(mhhh_version);
@@ -381,7 +381,7 @@
         // no difference, then no hunt occurred to separate them (i.e. a KR popped, or a friend hunt occurred).
         const required_differences = [
             "num_active_turns",
-            "next_activeturn_seconds"
+            "next_activeturn_seconds",
         ];
         const user_post = response.user;
 
@@ -535,7 +535,7 @@
             extension_version: formatVersion(mhhh_version),
             asset_package_hash: Date.now(),
             user_id: user_id,
-            entry_timestamp: Math.round(Date.now() / 1000)
+            entry_timestamp: Math.round(Date.now() / 1000),
         };
 
         // Send to database
@@ -545,7 +545,7 @@
     function sendMessageToServer(url, final_message) {
         const basic_info = {
             user_id: final_message.user_id,
-            entry_timestamp: final_message.entry_timestamp
+            entry_timestamp: final_message.entry_timestamp,
         };
 
         // Get UUID
@@ -587,7 +587,7 @@
                     extension_version: formatVersion(mhhh_version),
                     user_id: hunt_response.user.user_id,
                     rh_environment: markup.render_data.environment,
-                    entry_timestamp: markup.render_data.entry_timestamp
+                    entry_timestamp: markup.render_data.entry_timestamp,
                 };
                 // If this occurred after the daily reset, submit it. (Trap checks & friend hunts
                 // may appear and have been back-calculated as occurring before reset).
@@ -601,7 +601,7 @@
                 if (debug_logging) {
                     window.postMessage({
                         "mhct_log_request": 1,
-                        "prize mouse journal": markup
+                        "prize mouse journal": markup,
                     }, window.origin);
                 }
                 // TODO: Implement data submission
@@ -629,13 +629,13 @@
                             "is_error": true,
                             "desert heater journal": markup,
                             "inventory": hunt_response.inventory,
-                            "reason": `Didn't find named loot "${lootName}" in inventory`
+                            "reason": `Didn't find named loot "${lootName}" in inventory`,
                         }, window.origin);
                     } else {
                         const convertible = {
                             id: 2952, // Desert Heater Base's item ID
                             name: "Desert Heater Base",
-                            quantity: 1
+                            quantity: 1,
                         };
                         const items = [{ id: loot.item_id, name: lootName, quantity: lootQty }];
                         if (debug_logging) { window.console.log({ desert_heater_loot: items }); }
@@ -648,7 +648,7 @@
                         "is_error": true,
                         "desert heater journal": markup,
                         "inventory": hunt_response.inventory,
-                        "reason": "Didn't match quantity and loot name regex patterns"
+                        "reason": "Didn't match quantity and loot name regex patterns",
                     }, window.origin);
                 }
             }
@@ -668,13 +668,13 @@
                             "is_error": true,
                             "gilded charm journal": markup,
                             "inventory": hunt_response.inventory,
-                            "reason": "Unable to parse Gilded Charm proc quantity"
+                            "reason": "Unable to parse Gilded Charm proc quantity",
                         }, window.origin);
                     } else {
                         const convertible = {
                             id: 2174, // Gilded Charm's item ID
                             name: "Gilded Charm",
-                            quantity: 1
+                            quantity: 1,
                         };
                         const items = [{ id: 114, name: "SUPER|brie+", quantity: lootQty }];
                         if (debug_logging) { window.console.log({ gilded_charm: items }); }
@@ -706,7 +706,7 @@
     function createMessageFromHunt(journal, user, user_post) {
         const message = {
             extension_version: formatVersion(mhhh_version),
-            hunt_details: {}
+            hunt_details: {},
         };
         const debug_logs = [];
 
@@ -729,7 +729,7 @@
         }
         message.location = {
             name: user.environment_name,
-            id: user.environment_id
+            id: user.environment_id,
         };
         if (user_post.environment_id != user.environment_id) {
             debug_logs.push(`User auto-traveled from ${user.environment_name} to ${user_post.environment_name}`);
@@ -759,7 +759,7 @@
             { prop: 'weapon', message_field: 'trap', required: true, replacer: / trap$/i },
             { prop: 'base', message_field: 'base', required: true, replacer: / base$/i },
             { prop: 'bait', message_field: 'cheese', required: true, replacer: / cheese$/i },
-            { prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i }
+            { prop: 'trinket', message_field: 'charm', required: false, replacer: / charm$/i },
         ];
         // All pre-hunt users must have a weapon, base, and cheese.
         const missing = components.filter(component => component.required === true
@@ -776,7 +776,7 @@
             const item_name = user[prop_name];
             message[component.message_field] = (!item_name) ? {} : {
                 id: user[prop_id],
-                name: item_name.replace(component.replacer, '')
+                name: item_name.replace(component.replacer, ''),
             };
 
             if (item_name !== user_post[prop_name]) {
@@ -800,7 +800,7 @@
                     if (match && match.length && match.length === 3) {
                         message.hunt_details = Object.assign(message.hunt_details, {
                             "pillage_amount": parseInt(match[1].replace(/,/g,'')),
-                            "pillage_type": match[2]
+                            "pillage_type": match[2],
                         });
                     }
                 }
@@ -850,7 +850,7 @@
                 "false": {id: 41, name: "Cursed City"}},
             42: {"quest": "QuestSandDunes",
                 "true": {id: 5001, name: "Sand Dunes"},
-                "false": {id: 42, name: "Sand Crypts"}}
+                "false": {id: 42, name: "Sand Crypts"}},
         };
         const env = env_to_location[message.location.id];
         if (env) {
@@ -1008,7 +1008,7 @@
         const elements = user.quests.QuestMoussuPicchu.elements;
         message.stage = {
             rain: `Rain ${elements.rain.level}`,
-            wind: `Wind ${elements.wind.level}`
+            wind: `Wind ${elements.wind.level}`,
         };
     }
 
@@ -1199,7 +1199,7 @@
             "Icewing's Lair":       "1800ft",
             "Hidden Depths":   "1801-2000ft",
             "The Deep Lair":        "2000ft",
-            "General":            "Generals"
+            "General":            "Generals",
         })[quest.current_phase]);
 
         if (!message.stage) {
@@ -1289,7 +1289,7 @@
                 "Vault":      "Treasure 50+",
                 "Library":    "Scholar 80+",
                 "Manaforge":  "Tech 80+",
-                "Sanctum":    "Fealty 80+"
+                "Sanctum":    "Fealty 80+",
             };
             for (const [key, value] of Object.entries(zokor_stages)) {
                 const pattern = new RegExp(key, "i");
@@ -1328,7 +1328,7 @@
                 "charge_level_seven": "Battery 7",
                 "charge_level_eight": "Battery 8",
                 "charge_level_nine":  "Battery 9",
-                "charge_level_ten":   "Battery 10"
+                "charge_level_ten":   "Battery 10",
             })[quest.droid.charge_level]);
         }
 
@@ -1356,7 +1356,7 @@
             count_countess:       'Count/Countess',
             duke_dutchess:        'Duke/Duchess',
             grand_duke:           'Grand Duke/Duchess',
-            archduke_archduchess: 'Archduke/Archduchess'
+            archduke_archduchess: 'Archduke/Archduchess',
         };
         for (const [title, level] of Object.entries(titles)) {
             if (level.active) {
@@ -1385,7 +1385,7 @@
             "tier_0": "Mist 0",
             "tier_1": "Mist 1-5",
             "tier_2": "Mist 6-18",
-            "tier_3": "Mist 19-20"
+            "tier_3": "Mist 19-20",
         })[quest.mist_tier]);
         if (!message.stage) {
             if (debug_logging) {window.console.log({message: "Skipping unknown Burroughs Rift mist state", user, user_post, hunt});}
@@ -1437,7 +1437,7 @@
                         const has_correct_charm = (({
                             "door": 1210,
                             "rails": 1211,
-                            "roof": 1212
+                            "roof": 1212,
                         })[area] === charm_id);
                         if (has_correct_charm) {
                             stage += " - Defending Target";
@@ -1476,7 +1476,7 @@
                 "stage_two":   "Midnight",
                 "stage_three": "Pitch",
                 "stage_four":  "Utter Darkness",
-                "stage_five":  "First Light"
+                "stage_five":  "First Light",
             })[quest.current_stage]);
         }
 
@@ -1539,7 +1539,7 @@
                 "pumping_room":           "Pump Room",
                 "mixing_room":            "Mixing Room",
                 "break_room":             "Break Room",
-                "quality_assurance_room": "QA Room"
+                "quality_assurance_room": "QA Room",
             })[factory.current_room]);
             if (!message.stage) {
                 message.stage = "No Room";
@@ -1637,7 +1637,7 @@
         "Valour Rift": addValourRiftHuntDetails,
         "Whisker Woods Rift": addWhiskerWoodsRiftHuntDetails,
         "Zokor": addZokorHuntDetails,
-        "Zugzwang's Tower": addZugzwangsTowerHuntDetails
+        "Zugzwang's Tower": addZugzwangsTowerHuntDetails,
     };
 
     /**
@@ -1660,7 +1660,7 @@
             addEggHuntDetails,
             addHalloweenHuntDetails,
             addLNYHuntDetails,
-            addLuckyCatchHuntDetails
+            addLuckyCatchHuntDetails,
         ].forEach(details_func => details_func(message, user, user_post, hunt));
     }
 
@@ -1697,7 +1697,7 @@
             message.hunt_details = Object.assign(message.hunt_details || {}, {
                 is_halloween_hunt: true,
                 is_firing_cannon: !!(quest.is_cannon_enabled || quest.is_long_range_cannon_enabled),
-                is_in_stockpile: !!quest.has_stockpile
+                is_in_stockpile: !!quest.has_stockpile,
             });
         }
     }
@@ -1716,7 +1716,7 @@
                 is_lny_hunt: true,
                 lny_luck: (quest.lantern_status.includes("noLantern") || !quest.is_lantern_active)
                     ? 0
-                    : Math.min(50, Math.floor(parseInt(quest.lantern_height, 10) / 10))
+                    : Math.min(50, Math.floor(parseInt(quest.lantern_height, 10) / 10)),
             });
         }
     }
@@ -1731,7 +1731,7 @@
     function addLuckyCatchHuntDetails(message, user, user_post, hunt) {
         if (message.caught) {
             message.hunt_details = Object.assign(message.hunt_details || {}, {
-                is_lucky_catch: hunt.render_data.css_class.includes("luckycatchsuccess")
+                is_lucky_catch: hunt.render_data.css_class.includes("luckycatchsuccess"),
             });
         }
     }
@@ -1748,7 +1748,7 @@
         const details = {
             has_hourglass: quest.items.rift_hourglass_stat_item.quantity >= 1,
             chamber_status: quest.chamber_status,
-            cleaver_status: quest.cleaver_status
+            cleaver_status: quest.cleaver_status,
         };
         // Buffs & debuffs are 'active', 'removed', or ""
         for (const [key, value] of Object.entries(quest.status_effects)) {
@@ -1774,7 +1774,7 @@
         if (map && !map.is_complete) {
             message.hunt_details = Object.assign(message.hunt_details, {
                 poster_type: map.name.replace(/Wanted Poster/i, "").trim(),
-                at_boss: (map.remaining === 1)
+                at_boss: (map.remaining === 1),
             });
         }
     }
@@ -1818,7 +1818,7 @@
                 "desert_mage_strong",
                 "desert_cavalry",
                 "desert_cavalry_strong",
-                "desert_artillery"
+                "desert_artillery",
             ].filter(name => name in attrs.mice).forEach(mouse => {
                 const q = parseInt(attrs.mice[mouse].quantity, 10);
                 fw[`num_${asType(mouse)}`] = q;
@@ -1916,7 +1916,7 @@
         if (quest && !quest.is_normal && quest.minigame && quest.minigame.type === 'grubling') {
             if (["King Grub", "King Scarab"].includes(message.mouse)) {
                 message.hunt_details = Object.assign(message.hunt_details, {
-                    salt: quest.minigame.salt_charms_used
+                    salt: quest.minigame.salt_charms_used,
                 });
             }
         }
@@ -1935,7 +1935,7 @@
             const rage = {
                 clearing: parseInt(zones.clearing.level, 10),
                 tree: parseInt(zones.tree.level, 10),
-                lagoon: parseInt(zones.lagoon.level, 10)
+                lagoon: parseInt(zones.lagoon.level, 10),
             };
             const total_rage = rage.clearing + rage.tree + rage.lagoon;
             if (total_rage < 150 && total_rage >= 75) {
@@ -1960,7 +1960,7 @@
             message.hunt_details = Object.assign(message.hunt_details, {
                 minotaur_label: quest.boss.replace(/hiddenDistrict/i, "").trim(),
                 lair_catches: -(quest.countdown - 20),
-                minotaur_meter: parseFloat(quest.width)
+                minotaur_meter: parseFloat(quest.width),
             });
         } else if (quest.district_tier === 3) {
             message.hunt_details = Object.assign(message.hunt_details, {
@@ -1982,7 +1982,7 @@
         const zt = {
             amplifier: parseInt(attrs.zzt_amplifier, 10),
             technic: parseInt(attrs.zzt_tech_progress, 10),
-            mystic: parseInt(attrs.zzt_mage_progress, 10)
+            mystic: parseInt(attrs.zzt_mage_progress, 10),
         };
         zt.cm_available = (zt.technic === 16 || zt.mystic === 16) && message.cheese.id === 371;
         message.hunt_details = Object.assign(message.hunt_details, zt);
@@ -2059,7 +2059,7 @@
             id: item.item_id || item.id,
             name: item.name,
             // type: item.type,
-            quantity: item.quantity
+            quantity: item.quantity,
             // class: item.class || item.classification
         };
     }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -15,7 +15,7 @@
     }
     const mhhh_version = $("#mhhh_version").val();
 
-    var debug_logging = false;
+    let debug_logging = false;
 
     // Listening for calls
     window.addEventListener('message', ev => {
@@ -1577,7 +1577,7 @@
         const attrs = user.environment_atts || user.enviroment_atts;
         switch (attrs.state) {
             case "tower": {
-                let floor = attrs.floor;
+                const { floor } = attrs;
                 let stageName;
 
                 if (floor >= 1 && floor % 8 === 0) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -640,7 +640,7 @@
                         const items = [{ id: loot.item_id, name: lootName, quantity: lootQty }];
                         if (debug_logging) { window.console.log({ desert_heater_loot: items }); }
 
-                        submitConvertible(convertible, items, hunt_response.user.user_id)
+                        submitConvertible(convertible, items, hunt_response.user.user_id);
                     }
                 } else {
                     window.postMessage({
@@ -679,7 +679,7 @@
                         const items = [{ id: 114, name: "SUPER|brie+", quantity: lootQty }];
                         if (debug_logging) { window.console.log({ gilded_charm: items }); }
 
-                        submitConvertible(convertible, items, hunt_response.user.user_id)
+                        submitConvertible(convertible, items, hunt_response.user.user_id);
                     }
                 }
             }
@@ -2011,8 +2011,8 @@
 
     function addFloatingIslandsHuntDetails(message, user, user_post, hunt) {
         const envAttributes = user.environment_atts || user.enviroment_atts;
-        const huntingSiteAttributes = envAttributes.hunting_site_atts
-        const lootItems = huntingSiteAttributes.island_loot.reduce((prev, current) => Object.assign(prev, { [current.type]: current.quantity}), {})
+        const huntingSiteAttributes = envAttributes.hunting_site_atts;
+        const lootItems = huntingSiteAttributes.island_loot.reduce((prev, current) => Object.assign(prev, { [current.type]: current.quantity}), {});
 
         message.hunt_details = Object.assign(message.hunt_details, lootItems);
     }
@@ -2140,7 +2140,7 @@
                             }
                         });
                 }
-            }
+            };
 
             // Checks for route changes and then rescans for plain profiles
             const URLDiffCheck = () => {
@@ -2151,7 +2151,7 @@
                     localStorage.setItem("mhct-url-cache", currentURL);
                     profileAutoScan();
                 }
-            }
+            };
 
             URLDiffCheck(); // Initial call on page load
             $(document).ajaxStop(URLDiffCheck); // AJAX event listener for subsequent route changes

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2120,7 +2120,7 @@
 
         // If this page is a profile page, query the crown counts (if the user tracks crowns).
         if (settings.track_crowns) {
-            function profileAutoScan() {
+            const profileAutoScan = () => {
                 const profile_RE = /profile.php\?snuid=(\w+)$/g; // "$" at regex end = only auto-fetch when AJAX route changing onto a plain profile page
                 const profile_RE_matches = document.URL.match(profile_RE);
                 if (profile_RE_matches !== null && profile_RE_matches.length) {
@@ -2139,7 +2139,7 @@
             }
 
             // Checks for route changes and then rescans for plain profiles
-            function URLDiffCheck() {
+            const URLDiffCheck = () => {
                 const cachedURL = localStorage.getItem("mhct-url-cache");
                 const currentURL = document.URL;
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -517,7 +517,7 @@
 
     /**
      * @typedef {Object} HgItem
-     * @property {number} item_id HitGrab's ID for this item
+     * @property {number} id HitGrab's ID for this item
      * @property {string} name HitGrab's display name for this item
      * @property {number} quantity the number of this item received or opened
      */
@@ -526,7 +526,7 @@
      * Helper function to submit opened items.
      * @param {HgItem} convertible The item that was opened.
      * @param {HgItem[]} items An array of items that were obtained by opening the convertible
-     * @param {string} userId the user associated with the submission
+     * @param {string} user_id the user associated with the submission
      */
     function submitConvertible(convertible, items, user_id) {
         const record = {
@@ -1627,7 +1627,7 @@
         "Valour Rift": calcValourRiftHuntDetails,
         "Whisker Woods Rift": calcWhiskerWoodsRiftHuntDetails,
         "Zokor": calcZokorHuntDetails,
-        "Zugzwang's Tower": calcZugzwangsTowerHuntDetails
+        "Zugzwang's Tower": calcZugzwangsTowerHuntDetails,
     };
 
     /**
@@ -1692,7 +1692,7 @@
             return {
                 is_halloween_hunt: true,
                 is_firing_cannon: !!(quest.is_cannon_enabled || quest.is_long_range_cannon_enabled),
-                is_in_stockpile: !!quest.has_stockpile
+                is_in_stockpile: !!quest.has_stockpile,
             };
         }
     }
@@ -1711,7 +1711,7 @@
                 is_lny_hunt: true,
                 lny_luck: (quest.lantern_status.includes("noLantern") || !quest.is_lantern_active)
                     ? 0
-                    : Math.min(50, Math.floor(parseInt(quest.lantern_height, 10) / 10))
+                    : Math.min(50, Math.floor(parseInt(quest.lantern_height, 10) / 10)),
             };
         }
     }
@@ -1723,10 +1723,10 @@
      * @param {Object <string, any>} user_post The user state object, after the hunt.
      * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
      */
-    function calcLuckyCatchHuntDetails(message, user, user_post, { render_data }) {
+    function calcLuckyCatchHuntDetails(message, user, user_post, {render_data}) {
         if (message.caught) {
             return {
-                is_lucky_catch: render_data.css_class.includes("luckycatchsuccess")
+                is_lucky_catch: render_data.css_class.includes("luckycatchsuccess"),
             };
         }
     }
@@ -1738,7 +1738,7 @@
      * @param {Object <string, any>} user_post The user state object, after the hunt.
      * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
      */
-    function calcPillageHuntDetails(message, user, user_post, { render_data }) {
+    function calcPillageHuntDetails(message, user, user_post, {render_data}) {
         if (message.attracted && !message.caught && render_data.css_class.includes('catchfailuredamage')) {
             const match = render_data.text.match(/Additionally, .+ ([\d,]+) .*(gold|bait|points)/);
             if (match && match.length === 3) {
@@ -1876,10 +1876,10 @@
      */
     function calcFloatingIslandsHuntDetails(message, user, user_post, hunt) {
         const envAttributes = user.environment_atts || user.enviroment_atts;
-        const { island_loot } = envAttributes.hunting_site_atts
+        const {island_loot} = envAttributes.hunting_site_atts;
         const lootItems = island_loot.reduce((prev, current) => Object.assign(prev, {
-            [current.type]: current.quantity},
-        ), {});
+            [current.type]: current.quantity,
+        }), {});
 
         return lootItems;
     }
@@ -1992,7 +1992,7 @@
             const total_rage = rage.clearing + rage.tree + rage.lagoon;
             if (total_rage < 150 && total_rage >= 75) {
                 if (rage.clearing > 24 && rage.tree > 24 && rage.lagoon > 24) {
-                    return Object.assign(rage, { total_rage });
+                    return Object.assign(rage, {total_rage});
                 }
             }
         }
@@ -2012,7 +2012,7 @@
             return {
                 minotaur_label: quest.boss.replace(/hiddenDistrict/i, "").trim(),
                 lair_catches: -(quest.countdown - 20),
-                minotaur_meter: parseFloat(quest.width)
+                minotaur_meter: parseFloat(quest.width),
             };
         } else if (quest.district_tier === 3) {
             return {

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -1,5 +1,5 @@
 // JS script available only within the embedded options.html page
-let mhhhOptions = [
+const mhhhOptions = [
     {name: 'success_messages', p: 'checked', default: true},
     {name: 'error_messages', p: 'checked', default: true},
     {name: 'debug_logging', p: 'checked', default: false},

--- a/src/scripts/options.js
+++ b/src/scripts/options.js
@@ -13,7 +13,7 @@ const mhhhOptions = [
     {name: 'track_crowns', p: 'checked', default: true},
     {name: 'tsitu_loader_on', p: 'checked', default: false},
     {name: 'tsitu_loader_offset', p: 'value', default: 80},
-    {name: 'tsitu_loader_offset_output', p: 'value'}
+    {name: 'tsitu_loader_offset_output', p: 'value'},
 ];
 
 // Click "Save" -> store the extension's settings in chrome.storage.


### PR DESCRIPTION
This PR doesn't do too much for us just yet, but is step 1 in a longer process that will introduce tests and better code quality

This PR
1. allows us to declare development tooling, via `devDependencies`
2. Adds a small bit of code style enforcement
   - I chose not to enable rules for quote type or quoted object literal props, as we use both styles, and doing so here is a lot of noise
3. Creates two github workflows that provide some token level of feedback to contributions
   - the lint job will fail if code is not valid javascript
   - the test job will be useless until we have tests, but when we do (and make the package.json test script run them, then GitHub will automatically run tests on push & PR
4. Create a jsconfig.json project config, for those who use VS Code, which provides type signatures for the Chrome / WebExtensions APIs

In the future, we can use this development environment to introduce a bundling/compiling process for generating releases, which means we can split up `main.js` into testable components. We can possibly also explore virtual DOM testing solutions, and inject parts of the code. It may also be possible to use a sandbox browser env, to actually test the extension's bootstrapping. (I haven't looked into any kinds of integration testing solutions for browser extensions, but I can only assume they exist.)